### PR TITLE
Fix ImportError by setting Werkzeug to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.2
+Werkzeug==2.2.2
 gqlalchemy==1.1.2


### PR DESCRIPTION
This PR updates `requirements.txt` to specify `Werkzeug==2.2.2`, addressing an issue where the application fails to start due to the following error:

```shell
card-fraud-card_fraud-1  | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py)
```